### PR TITLE
Allowing the usage without being a service

### DIFF
--- a/src/NCron/ApplicationInfo.cs
+++ b/src/NCron/ApplicationInfo.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace NCron
+{
+    internal static class ApplicationInfo
+    {
+        public static readonly string ApplicationName = Assembly.GetEntryAssembly().GetName().Name;
+    }
+}

--- a/src/NCron/ExceptionHelper.cs
+++ b/src/NCron/ExceptionHelper.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+using System.Reflection;
+using NCron.Service;
+
+namespace NCron
+{
+    internal static class ExceptionHelper
+    {
+        // We explicitly use the EventLog for logging purposes in the main exception handling.
+        // If the configuration cannot be loaded - and no log factory created - it will be logged.
+        // If a custom ILog implementation throws, this will also be logged here.
+        private static readonly EventLog CoreLog = new EventLog { Source = ApplicationInfo.ApplicationName };
+
+        internal static void LogUnhandledException(object exception) {
+            CoreLog.WriteEntry("An unhandled exception has occured. " + exception, EventLogEntryType.Error);
+        }
+    }
+}

--- a/src/NCron/Fluent/Crontab/Extensions.cs
+++ b/src/NCron/Fluent/Crontab/Extensions.cs
@@ -31,7 +31,7 @@ namespace NCron.Fluent.Crontab
         /// <param name="service">The service to which the schedule should be added.</param>
         /// <param name="crontab">A crontab expression describing the schedule.</param>
         /// <returns>A part that allows chained fluent method calls.</returns>
-        public static SchedulePart At(this SchedulingService service, string crontab)
+        public static SchedulePart At(this ISchedulingService service, string crontab)
         {
             var schedule = CrontabSchedule.Parse(crontab);
             return service.At(schedule.GetNextOccurrence);
@@ -42,7 +42,7 @@ namespace NCron.Fluent.Crontab
         /// </summary>
         /// <param name="service">The service to which the schedule should be added.</param>
         /// <returns>A part that allows chained fluent method calls.</returns>
-        public static SchedulePart Hourly(this SchedulingService service)
+        public static SchedulePart Hourly(this ISchedulingService service)
         {
             return service.At("01 * * * *");
         }
@@ -52,7 +52,7 @@ namespace NCron.Fluent.Crontab
         /// </summary>
         /// <param name="service">The service to which the schedule should be added.</param>
         /// <returns>A part that allows chained fluent method calls.</returns>
-        public static SchedulePart Daily(this SchedulingService service)
+        public static SchedulePart Daily(this ISchedulingService service)
         {
             return service.At("02 4 * * *");
         }
@@ -62,7 +62,7 @@ namespace NCron.Fluent.Crontab
         /// </summary>
         /// <param name="service">The service to which the schedule should be added.</param>
         /// <returns>A part that allows chained fluent method calls.</returns>
-        public static SchedulePart Weekly(this SchedulingService service)
+        public static SchedulePart Weekly(this ISchedulingService service)
         {
             return service.At("22 4 * * 0");
         }
@@ -72,7 +72,7 @@ namespace NCron.Fluent.Crontab
         /// </summary>
         /// <param name="service">The service to which the schedule should be added.</param>
         /// <returns>A part that allows chained fluent method calls.</returns>
-        public static SchedulePart Monthly(this SchedulingService service)
+        public static SchedulePart Monthly(this ISchedulingService service)
         {
             return service.At("42 4 1 * *");
         }

--- a/src/NCron/Fluent/Extensions.cs
+++ b/src/NCron/Fluent/Extensions.cs
@@ -30,7 +30,7 @@ namespace NCron.Fluent
         /// <param name="service">The service to which the schedule should be added.</param>
         /// <param name="schedule">A method for calculating the next occurence from a specified base.</param>
         /// <returns>A part that allows chained fluent method calls.</returns>
-        public static SchedulePart At(this SchedulingService service, Func<DateTime, DateTime> schedule)
+        public static SchedulePart At(this ISchedulingService service, Func<DateTime, DateTime> schedule)
         {
             return new SchedulePart(service, schedule);
         }

--- a/src/NCron/Fluent/JobPart.cs
+++ b/src/NCron/Fluent/JobPart.cs
@@ -23,10 +23,10 @@ namespace NCron.Fluent
     /// </summary>
     public class JobPart
     {
-        private readonly SchedulingService _service;
+        private readonly ISchedulingService _service;
         private readonly ScheduledJob _queueEntry;
 
-        internal JobPart(SchedulingService service, ScheduledJob queueEntry)
+        internal JobPart(ISchedulingService service, ScheduledJob queueEntry)
         {
             _service = service;
             _queueEntry = queueEntry;

--- a/src/NCron/Fluent/SchedulePart.cs
+++ b/src/NCron/Fluent/SchedulePart.cs
@@ -24,10 +24,10 @@ namespace NCron.Fluent
     /// </summary>
     public class SchedulePart
     {
-        private readonly SchedulingService _service;
+        private readonly ISchedulingService _service;
         private readonly Func<DateTime, DateTime> _schedule;
 
-        internal SchedulePart(SchedulingService service, Func<DateTime, DateTime> schedule)
+        internal SchedulePart(ISchedulingService service, Func<DateTime, DateTime> schedule)
         {
             _service = service;
             _schedule = schedule;
@@ -72,11 +72,11 @@ namespace NCron.Fluent
     public class SchedulePart<TContainer>
         where TContainer : IDisposable
     {
-        private readonly SchedulingService _service;
+        private readonly ISchedulingService _service;
         private readonly Func<DateTime, DateTime> _schedule;
         private readonly Func<TContainer> _containerCallback;
 
-        internal SchedulePart(SchedulingService service, Func<DateTime, DateTime> schedule, Func<TContainer> containerCallback)
+        internal SchedulePart(ISchedulingService service, Func<DateTime, DateTime> schedule, Func<TContainer> containerCallback)
         {
             _service = service;
             _schedule = schedule;

--- a/src/NCron/Logging/DefaultLogFactory.cs
+++ b/src/NCron/Logging/DefaultLogFactory.cs
@@ -38,7 +38,7 @@ namespace NCron.Logging
         /// <returns>An <see cref="EventLogAdapter"/>, writing to the "Application" event log with a source name of "NCron".</returns>
         public ILog GetLogForJob(ICronJob job)
         {
-            var eventLog = new EventLog { Source = Bootstrap.ApplicationName };
+            var eventLog = new EventLog { Source = ApplicationInfo.ApplicationName };
             return new EventLogAdapter(eventLog);
         }
     }

--- a/src/NCron/NCron.csproj
+++ b/src/NCron/NCron.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ExceptionHelper.cs" />
     <Compile Include="Fluent\Extensions.cs" />
     <Compile Include="Fluent\Generics\Extensions.cs" />
     <Compile Include="Fluent\JobPart.cs" />
@@ -74,7 +75,9 @@
     <Compile Include="Logging\DefaultLogFactory.cs" />
     <Compile Include="Logging\ILog.cs" />
     <Compile Include="Logging\ILogFactory.cs" />
+    <Compile Include="ApplicationInfo.cs" />
     <Compile Include="Service\Delegates.cs" />
+    <Compile Include="Service\ISchedulingService.cs" />
     <Compile Include="Service\ProjectInstaller.cs">
     </Compile>
     <Compile Include="Service\ScheduledJob.cs" />

--- a/src/NCron/Service/ISchedulingService.cs
+++ b/src/NCron/Service/ISchedulingService.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using NCron.Logging;
+
+namespace NCron.Service
+{
+    /// <summary>
+    /// Executes jobs according to specified schedules.
+    /// </summary>
+    public interface ISchedulingService
+    {
+        /// <summary>
+        /// Sets the log factory that is used to create a log for each job execution.
+        /// </summary>
+        ILogFactory LogFactory { set; }
+
+        /// <summary>
+        /// Adds a scheduled job for automatic execution by this service.
+        /// </summary>
+        /// <param name="schedule">A method for computation of occurrences in the schedule, taking last execution as parameter.</param>
+        /// <param name="executionWrapper">The execution wrapper method to be invoked on each occurence of the job.</param>
+        /// <returns>The newly scheduled job.</returns>
+        ScheduledJob AddScheduledJob(Func<DateTime, DateTime> schedule, JobExecutionWrapper executionWrapper);
+
+        /// <summary>
+        /// Adds a named job for manual execution by this service.
+        /// </summary>
+        /// <param name="name">The name under which the job should be registered.</param>
+        /// <param name="executionWrapper">The execution wrapper method to be invoked on each invocation of the job.</param>
+        void AddNamedJob(string name, JobExecutionWrapper executionWrapper);
+
+        /// <summary>
+        /// Starts the scheduling service.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops the scheduling service.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/src/NCron/Service/SchedulingService.cs
+++ b/src/NCron/Service/SchedulingService.cs
@@ -24,7 +24,7 @@ namespace NCron.Service
     /// <summary>
     /// Executes jobs according to specified schedules.
     /// </summary>
-    public class SchedulingService : IDisposable
+    public class SchedulingService : IDisposable, ISchedulingService
     {
         private readonly Timer _timer;
         private readonly IPriorityQueue<ScheduledJob> _queue;
@@ -40,7 +40,7 @@ namespace NCron.Service
             set { _logFactory = value; }
         }
 
-        internal SchedulingService()
+        public SchedulingService()
         {
             _timer = new Timer(TimerCallbackHandler);
             _queue = new IntervalHeap<ScheduledJob>();
@@ -71,13 +71,13 @@ namespace NCron.Service
             _namedEntries.Add(name, executionWrapper);
         }
 
-        internal void Start()
+        public void Start()
         {
             _head = _queue.DeleteMin();
             TimerCallbackHandler(null);
         }
 
-        internal void Stop()
+        public void Stop()
         {
             _timer.Change(Timeout.Infinite, Timeout.Infinite);
         }
@@ -111,7 +111,7 @@ namespace NCron.Service
             }
             catch (Exception exception)
             {
-                Bootstrap.LogUnhandledException(exception);
+                ExceptionHelper.LogUnhandledException(exception);
             }
         }
 

--- a/src/NCron/Service/ServiceProcessAdapter.cs
+++ b/src/NCron/Service/ServiceProcessAdapter.cs
@@ -21,9 +21,9 @@ namespace NCron.Service
     [System.ComponentModel.DesignerCategory("Code")]
     internal class ServiceProcessAdapter : ServiceBase
     {
-        private readonly SchedulingService _service;
+        private readonly ISchedulingService _service;
         
-        public ServiceProcessAdapter(SchedulingService service)
+        public ServiceProcessAdapter(ISchedulingService service)
         {
             _service = service;
         }


### PR DESCRIPTION
I changed SchedulingService members visibility and created an interface allowing it to be instantiated outside the assembly (thus, allowing the usage without installing as a service). I also removed a circular dependency with Bootstrap (by simply creating a helper class).
I've also changed the extension methods to use the interface ISchedulingService.
